### PR TITLE
Fix release workflow failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,7 @@ jobs:
       - name: Run tests
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/eventcore_test
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/eventcore_test
         run: cargo test --workspace
       
       - name: Publish crates

--- a/website/sync-docs.sh
+++ b/website/sync-docs.sh
@@ -10,7 +10,8 @@ if [ -f "src/manual/07-reference/01-api-documentation.md" ]; then
     cp src/manual/07-reference/01-api-documentation.md /tmp/api-doc-backup.md
 fi
 
-cp -r ../docs/manual/* src/manual/
+# Skip copying manual docs since docs/manual is a symlink to src/manual
+# cp -r ../docs/manual/* src/manual/
 
 # Restore the API documentation file
 if [ -f "/tmp/api-doc-backup.md" ]; then


### PR DESCRIPTION
## Description

This PR fixes two critical issues that were preventing successful releases:

1. **Documentation publishing failure**: The `sync-docs.sh` script was failing because it tried to copy from `docs/manual` to `website/src/manual`, but `docs/manual` is actually a symlink pointing to `website/src/manual`. This caused `cp` to fail with "same file" errors.

2. **PostgreSQL test failures**: Integration tests were timing out during the crate publishing step because they expect the `TEST_DATABASE_URL` environment variable, but the workflow was only setting `DATABASE_URL`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Submitter Checklist

- [x] Tests pass locally
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated if needed
- [x] No new warnings introduced
- [x] Dependent changes merged

## Performance Impact

No performance impact - these are CI/CD workflow fixes only.

## Review Focus

Please verify:
- The `sync-docs.sh` change doesn't break documentation generation
- The PostgreSQL test environment variable is correct for all test scenarios