### PR TITLE
Fix additional release workflow failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,7 @@ jobs:
           EOF
           
           # Add CSS for version banner
+          mkdir -p website/book/theme/css
           cat >> website/book/theme/css/custom.css << EOF
           
           .version-banner {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,12 @@ parking_lot = "0.12.4"
 # Async stream utilities
 futures = "0.3.31"
 
+# Internal workspace crates
+eventcore = { version = "0.1.0", path = "eventcore" }
+eventcore-postgres = { version = "0.1.0", path = "eventcore-postgres" }
+eventcore-memory = { version = "0.1.0", path = "eventcore-memory" }
+eventcore-macros = { version = "0.1.0", path = "eventcore-macros" }
+
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/PLANNING.md
+++ b/PLANNING.md
@@ -309,6 +309,10 @@ All documented implementation phases have been completed. The project is ready f
 - [x] Fixed additional Cargo.toml syntax errors and dependency versions in PR #33:
   - Fixed `rand.workspace = true` syntax error to `rand = { workspace = true }`
   - Added missing version to eventcore-memory dev-dependency
+  - Implemented workspace dependencies for internal crates to enable automatic lockstep versioning
+  - Added all internal crates to workspace.dependencies in root Cargo.toml with path + version
+  - Updated all internal dependency references to use `{ workspace = true }`
+  - Eliminates manual version updates when bumping workspace version for releases
 
 ## Pull Request Workflow
 

--- a/PLANNING.md
+++ b/PLANNING.md
@@ -301,6 +301,15 @@ All documented implementation phases have been completed. The project is ready f
   - Removed unnecessary runtime parameter from `PeriodicReader::builder()`
   - Added required `grpc-tonic` feature to opentelemetry-otlp dependency
 
+### Release Workflow Fixes (2025-07-07)
+- [x] Fixed PostgreSQL test configuration (missing TEST_DATABASE_URL) in PR #31
+- [x] Fixed documentation sync script symlink issue in PR #31
+- [x] Fixed Cargo.toml version specifications for crates.io publishing in PR #33
+- [x] Fixed CSS directory creation for documentation builds in PR #33
+- [x] Fixed additional Cargo.toml syntax errors and dependency versions in PR #33:
+  - Fixed `rand.workspace = true` syntax error to `rand = { workspace = true }`
+  - Added missing version to eventcore-memory dev-dependency
+
 ## Pull Request Workflow
 
 This project uses a **pull request-based workflow**. Direct commits to the main branch are not allowed. All changes must go through pull requests for review and CI validation.

--- a/eventcore-benchmarks/Cargo.toml
+++ b/eventcore-benchmarks/Cargo.toml
@@ -15,9 +15,9 @@ description = "Benchmarks for the EventCore multi-stream event sourcing library"
 workspace = true
 
 [dependencies]
-eventcore = { path = "../eventcore", features = ["testing"] }
-eventcore-memory = { path = "../eventcore-memory" }
-eventcore-postgres = { path = "../eventcore-postgres" }
+eventcore = { workspace = true, features = ["testing"] }
+eventcore-memory = { workspace = true }
+eventcore-postgres = { workspace = true }
 tokio = { workspace = true }
 criterion = { workspace = true, features = ["async_futures"] }
 async-trait = { workspace = true }

--- a/eventcore-examples/Cargo.toml
+++ b/eventcore-examples/Cargo.toml
@@ -11,10 +11,10 @@ publish = false
 
 [dependencies]
 # Core dependencies
-eventcore = { path = "../eventcore", features = ["testing"] }
-eventcore-macros = { path = "../eventcore-macros" }
-eventcore-postgres = { path = "../eventcore-postgres" }
-eventcore-memory = { path = "../eventcore-memory" }
+eventcore = { workspace = true, features = ["testing"] }
+eventcore-macros = { workspace = true }
+eventcore-postgres = { workspace = true }
+eventcore-memory = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }

--- a/eventcore-macros/Cargo.toml
+++ b/eventcore-macros/Cargo.toml
@@ -19,5 +19,5 @@ quote = "1.0.40"
 proc-macro2 = "1.0.95"
 
 [dev-dependencies]
-eventcore = { path = "../eventcore" }
+eventcore = { workspace = true }
 trybuild = "1.0"

--- a/eventcore-memory/Cargo.toml
+++ b/eventcore-memory/Cargo.toml
@@ -13,7 +13,7 @@ description = "In-memory adapter for EventCore event sourcing library (for testi
 
 [dependencies]
 # Core dependencies
-eventcore = { path = "../eventcore", version = "0.1.0" }
+eventcore = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }

--- a/eventcore-memory/Cargo.toml
+++ b/eventcore-memory/Cargo.toml
@@ -13,7 +13,7 @@ description = "In-memory adapter for EventCore event sourcing library (for testi
 
 [dependencies]
 # Core dependencies
-eventcore = { path = "../eventcore" }
+eventcore = { path = "../eventcore", version = "0.1.0" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }

--- a/eventcore-postgres/Cargo.toml
+++ b/eventcore-postgres/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { workspace = true }
 # PostgreSQL specific
 sqlx = { workspace = true }
 parking_lot = { workspace = true }
-rand.workspace = true
+rand = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
@@ -35,7 +35,7 @@ insta = { workspace = true }
 criterion = { workspace = true }
 tracing-subscriber = { workspace = true }
 testcontainers = { workspace = true }
-eventcore-memory = { path = "../eventcore-memory" }
+eventcore-memory = { path = "../eventcore-memory", version = "0.1.0" }
 futures = { workspace = true }
 
 # Temporarily disabled until Command API migration is complete

--- a/eventcore-postgres/Cargo.toml
+++ b/eventcore-postgres/Cargo.toml
@@ -13,7 +13,7 @@ description = "PostgreSQL adapter for EventCore event sourcing library"
 
 [dependencies]
 # Core dependencies
-eventcore = { path = "../eventcore" }
+eventcore = { path = "../eventcore", version = "0.1.0" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }

--- a/eventcore-postgres/Cargo.toml
+++ b/eventcore-postgres/Cargo.toml
@@ -13,7 +13,7 @@ description = "PostgreSQL adapter for EventCore event sourcing library"
 
 [dependencies]
 # Core dependencies
-eventcore = { path = "../eventcore", version = "0.1.0" }
+eventcore = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
@@ -35,7 +35,7 @@ insta = { workspace = true }
 criterion = { workspace = true }
 tracing-subscriber = { workspace = true }
 testcontainers = { workspace = true }
-eventcore-memory = { path = "../eventcore-memory", version = "0.1.0" }
+eventcore-memory = { workspace = true }
 futures = { workspace = true }
 
 # Temporarily disabled until Command API migration is complete

--- a/eventcore/Cargo.toml
+++ b/eventcore/Cargo.toml
@@ -55,8 +55,8 @@ criterion = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-test = "0.2.5"
 rand = { workspace = true }
-eventcore-memory = { path = "../eventcore-memory" }
-eventcore-postgres = { path = "../eventcore-postgres" }
+eventcore-memory = { workspace = true }
+eventcore-postgres = { workspace = true }
 axum = { version = "0.8", features = ["tokio"] }
 
 [features]


### PR DESCRIPTION
## Description

This PR fixes two additional issues discovered after the previous release workflow fix:

1. **Crates.io publishing failure**: The eventcore-postgres and eventcore-memory crates failed to publish because their dependencies on eventcore didn't specify a version. When publishing to crates.io, cargo requires all dependencies to have explicit versions even if they're path dependencies.

2. **Documentation CSS path issue**: The documentation publishing failed because the release workflow tried to append CSS to `website/book/theme/css/custom.css`, but the `css` directory didn't exist. mdBook doesn't automatically create subdirectories under `theme`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Submitter Checklist

- [x] Tests pass locally
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated if needed
- [x] No new warnings introduced
- [x] Dependent changes merged

## Performance Impact

No performance impact - these are CI/CD workflow and dependency declaration fixes only.

## Review Focus

Please verify:
- The version specifications in Cargo.toml files are correct
- The mkdir command placement in the workflow doesn't interfere with mdBook's operation