### PR TITLE
Fix version conflicts preventing v0.1.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 authors = ["EventCore Contributors"]
 edition = "2021"
 rust-version = "1.70.0"
@@ -52,10 +52,10 @@ parking_lot = "0.12.4"
 futures = "0.3.31"
 
 # Internal workspace crates
-eventcore = { version = "0.1.0", path = "eventcore" }
-eventcore-postgres = { version = "0.1.0", path = "eventcore-postgres" }
-eventcore-memory = { version = "0.1.0", path = "eventcore-memory" }
-eventcore-macros = { version = "0.1.0", path = "eventcore-macros" }
+eventcore = { version = "0.1.1", path = "eventcore" }
+eventcore-postgres = { version = "0.1.1", path = "eventcore-postgres" }
+eventcore-memory = { version = "0.1.1", path = "eventcore-memory" }
+eventcore-macros = { version = "0.1.1", path = "eventcore-macros" }
 
 
 [workspace.lints.rust]

--- a/PLANNING.md
+++ b/PLANNING.md
@@ -313,6 +313,11 @@ All documented implementation phases have been completed. The project is ready f
   - Added all internal crates to workspace.dependencies in root Cargo.toml with path + version
   - Updated all internal dependency references to use `{ workspace = true }`
   - Eliminates manual version updates when bumping workspace version for releases
+- [x] Fixed version conflicts preventing re-release after partial crates.io publishing:
+  - v0.1.0 release failed after publishing eventcore-macros but before publishing other crates
+  - Deleted failed v0.1.0 release and tag from GitHub
+  - Bumped workspace version to 0.1.1 to avoid crates.io version conflicts
+  - Updated all internal crate versions to 0.1.1 in workspace dependencies
 
 ## Pull Request Workflow
 


### PR DESCRIPTION
$(cat <<'EOF'
## Description

The v0.1.0 release failed after eventcore-macros was already published to crates.io but before the other crates could be published. Since crates.io doesn't allow republishing the same version, subsequent release attempts were failing with version conflicts.

This PR resolves the issue by:
- Deleting the failed v0.1.0 release and tag from GitHub
- Bumping the workspace version from 0.1.0 to 0.1.1 
- Updating all internal workspace dependency versions to 0.1.1

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Submitter Checklist

- [x] Tests pass locally
- [x] Code follows project style guidelines  
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated if needed
- [x] No new warnings introduced
- [x] Dependent changes merged

## Performance Impact

No performance impact - this is purely a version number change to resolve crates.io publishing conflicts.

## Review Focus

Please verify that the version bump approach is correct and that all internal crate versions are consistently updated to 0.1.1.
EOF
)