### PR TITLE
Configure Dependabot to ignore internal workspace crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,14 @@ updates:
     # They also ignore the open-pull-requests-limit
     allow:
       - dependency-type: "all"
+    # Ignore internal workspace crates - these are versioned together
+    ignore:
+      - dependency-name: "eventcore"
+      - dependency-name: "eventcore-postgres"
+      - dependency-name: "eventcore-memory"
+      - dependency-name: "eventcore-macros"
+      - dependency-name: "eventcore-examples"
+      - dependency-name: "eventcore-benchmarks"
     commit-message:
       prefix: "deps"
       include: "scope"

--- a/PLANNING.md
+++ b/PLANNING.md
@@ -353,6 +353,13 @@ All documented implementation phases have been completed. The project is ready f
   - Must copy all checkboxes, headers, and structure exactly as written
   - Only fill in description content areas, never modify template structure
 
+### Dependency Management (2025-07-07)
+- [x] Fixed Dependabot creating PRs for internal workspace crates:
+  - Problem: Dependabot was suggesting version updates for our own workspace crates
+  - Cause: Internal crates listed in workspace.dependencies with version numbers
+  - Solution: Added ignore rules in dependabot.yml for all internal workspace crates
+  - This prevents spurious PRs while keeping version numbers for crates.io publishing
+
 ## Pull Request Workflow
 
 This project uses a **pull request-based workflow**. Direct commits to the main branch are not allowed. All changes must go through pull requests for review and CI validation.


### PR DESCRIPTION
## Description

Dependabot was creating pull requests to update versions of our own workspace crates (eventcore, eventcore-postgres, etc.) because it doesn't recognize that these are internal dependencies that should version together with the workspace.

This PR adds ignore rules for all workspace member crates in the Dependabot configuration. This is the correct solution rather than removing version numbers from workspace.dependencies, which would break cargo publish to crates.io.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Security enhancement

## Performance Impact

No performance impact - this only affects Dependabot behavior.

<details>
<summary>Benchmark Results</summary>

```bash
# Run benchmarks before and after changes:
git checkout main
cargo bench --bench event_store -- --save-baseline main
git checkout your-branch
cargo bench --bench event_store -- --baseline main

# For realistic workload benchmarks:
cargo bench --bench realistic_workloads -- --save-baseline main
# ... switch branches ...
cargo bench --bench realistic_workloads -- --baseline main
```

</details>

## Submitter Checklist

- [ ] Code follows project style guidelines
- [ ] Changes are well-documented
- [ ] All tests pass
- [ ] Performance implications have been considered
- [ ] Security implications have been reviewed
- [ ] Breaking changes are documented
- [ ] The change is backward compatible where possible

## Review Focus

Please verify that all workspace member crates are included in the ignore list. The list should match all members defined in the root Cargo.toml workspace.