### PR TITLE
Fix release-plz workflow action reference

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,7 @@ name: Release-plz
 permissions:
   pull-requests: write
   contents: write
+  id-token: write  # For publishing to crates.io
 
 on:
   push:
@@ -24,7 +25,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: release-plz/action@v0.5.102
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        with:
+          # Enable debug output
+          rust_log: debug


### PR DESCRIPTION
## Description

Fixes the release-plz workflow which has been failing silently due to an outdated action reference.

The release-plz GitHub Action has moved from `MarcoIeni/release-plz-action` to `release-plz/action`. The old repository location no longer exists, causing the workflow to fail without any output.

This PR updates the action reference to the correct location and adds debug logging for better troubleshooting.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Security enhancement

## Performance Impact

Not applicable - this change only affects CI/CD workflows.

## Submitter Checklist

- [ ] Code follows project style guidelines
- [ ] Changes are well-documented
- [ ] All tests pass
- [ ] Performance implications have been considered
- [ ] Security implications have been reviewed
- [ ] Breaking changes are documented
- [ ] The change is backward compatible where possible

## Review Focus

- Verify the new action reference `release-plz/action@v0.5.102` is correct
- Check that the added `id-token: write` permission is appropriate for crates.io publishing
- Confirm debug logging configuration looks reasonable