### PR TITLE
Fix release-plz configuration field name

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,6 @@
 [workspace]
 # Update all workspace members together
-members_release_always = true
+release_always = true
 
 # Allow dirty working directory (for CI)
 allow_dirty = true


### PR DESCRIPTION
## Description

Fixed release-plz workflow failing due to incorrect configuration field name. Changed `members_release_always` to `release_always` which is the correct field name according to release-plz documentation.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Security enhancement

## Performance Impact

None - this is a CI configuration change only

## Submitter Checklist

- [ ] Code follows project style guidelines
- [ ] Changes are well-documented
- [ ] All tests pass
- [ ] Performance implications have been considered
- [ ] Security implications have been reviewed
- [ ] Breaking changes are documented
- [ ] The change is backward compatible where possible

## Review Focus

Simple configuration fix - just verify the field name is correct according to release-plz documentation