### PR TITLE
Temporarily disable dependencies_update for initial release

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,8 +6,7 @@ release_always = true
 allow_dirty = true
 
 # Dependencies update
-# TODO: Re-enable after initial release (temporarily disabled because workspace
-# dependencies are not yet published to crates.io)
+# TODO: Re-enable after initial release (temporarily disabled because workspace dependencies are not yet published to crates.io)
 dependencies_update = false
 
 # Git configuration

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,7 +6,9 @@ release_always = true
 allow_dirty = true
 
 # Dependencies update
-dependencies_update = true
+# TODO: Re-enable after initial release (temporarily disabled because workspace
+# dependencies are not yet published to crates.io)
+dependencies_update = false
 
 # Git configuration
 git_release_enable = true  # Create GitHub releases


### PR DESCRIPTION
## Description

Disabled dependencies_update in release-plz.toml to fix the chicken-and-egg problem where the workflow tries to fetch workspace dependencies that don't exist on crates.io yet. This is a temporary change that should be reverted after the initial release succeeds.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Security enhancement

## Performance Impact

None - this is a CI configuration change only

## Submitter Checklist

- [x] Code follows project style guidelines
- [x] Changes are well-documented
- [x] All tests pass
- [x] Performance implications have been considered
- [x] Security implications have been reviewed
- [x] Breaking changes are documented
- [x] The change is backward compatible where possible

## Review Focus

This is a temporary workaround. The TODO comment reminds us to re-enable dependencies_update after all packages are published to crates.io.