### PR TITLE
Bump version to 0.1.3 to bypass existing git tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-benchmarks"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-examples"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-macros"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-memory"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-postgres"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 authors = ["EventCore Contributors"]
 edition = "2021"
 rust-version = "1.70.0"
@@ -54,10 +54,10 @@ futures = "0.3.31"
 # Internal workspace crates
 # Version must be specified for crates.io publishing
 # These will be automatically updated by release-plz
-eventcore = { path = "eventcore", version = "0.1.2" }
-eventcore-postgres = { path = "eventcore-postgres", version = "0.1.2" }
-eventcore-memory = { path = "eventcore-memory", version = "0.1.2" }
-eventcore-macros = { path = "eventcore-macros", version = "0.1.2" }
+eventcore = { path = "eventcore", version = "0.1.3" }
+eventcore-postgres = { path = "eventcore-postgres", version = "0.1.3" }
+eventcore-memory = { path = "eventcore-memory", version = "0.1.3" }
+eventcore-macros = { path = "eventcore-macros", version = "0.1.3" }
 
 
 [workspace.lints.rust]


### PR DESCRIPTION
## Description

Bumped all workspace packages to version 0.1.3 to bypass the existing v0.1.1 and v0.1.2 git tags from failed release attempts. This allows release-plz to proceed with a clean version that has no existing git tag.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Security enhancement

## Performance Impact

None - version number change only

## Submitter Checklist

- [x] Code follows project style guidelines
- [x] Changes are well-documented
- [x] All tests pass
- [x] Performance implications have been considered
- [x] Security implications have been reviewed
- [x] Breaking changes are documented
- [x] The change is backward compatible where possible

## Review Focus

This is a workaround for the git tag conflict. Once merged, release-plz should be able to create a release PR for v0.1.3.