### PR TITLE
Configure release-plz to only create PRs, not publish

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,5 +1,18 @@
 name: Release-plz
 
+# This workflow creates release PRs when changes are pushed to main.
+# It only runs the 'release-pr' command to avoid circular dependency issues
+# during initial publishing of workspace crates.
+#
+# To actually publish to crates.io:
+# 1. Merge the release PR created by this workflow
+# 2. Manually run 'cargo publish' for each crate in dependency order:
+#    - eventcore-macros
+#    - eventcore
+#    - eventcore-memory
+#    - eventcore-postgres
+# 3. Once all crates are published, re-enable dependencies_update in release-plz.toml
+
 permissions:
   pull-requests: write
   contents: write
@@ -30,5 +43,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:
+          # Only create PR, don't release yet
+          # This prevents circular dependency issues during initial publishing
+          command: release-pr
           # Enable debug output
           rust_log: debug


### PR DESCRIPTION
## Description

Fixed release-plz workflow to only run the 'release-pr' command instead of both 'release-pr' and 'release'. This prevents the circular dependency error where eventcore can't be published because eventcore-memory isn't on crates.io yet.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Security enhancement

## Performance Impact

None - this is a CI workflow change only

## Submitter Checklist

- [x] Code follows project style guidelines
- [x] Changes are well-documented
- [x] All tests pass
- [x] Performance implications have been considered
- [x] Security implications have been reviewed
- [x] Breaking changes are documented
- [x] The change is backward compatible where possible

## Review Focus

The workflow now only creates release PRs. Manual publishing will be needed for the initial release, then we can update the workflow to handle publishing automatically.