### PR TITLE
Use PAT for release-plz to trigger CI on release PRs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,17 +1,18 @@
 name: Release-plz
 
 # This workflow creates release PRs when changes are pushed to main.
-# It only runs the 'release-pr' command to avoid circular dependency issues
-# during initial publishing of workspace crates.
+# It uses a Personal Access Token (PAT) instead of GITHUB_TOKEN to ensure
+# that CI workflows are triggered on the created PR.
 #
-# To actually publish to crates.io:
-# 1. Merge the release PR created by this workflow
-# 2. Manually run 'cargo publish' for each crate in dependency order:
-#    - eventcore-macros
-#    - eventcore
-#    - eventcore-memory
-#    - eventcore-postgres
-# 3. Once all crates are published, re-enable dependencies_update in release-plz.toml
+# Setup:
+# Uses the existing PR_DRAFT_PAT secret which has the necessary permissions
+#
+# The workflow will:
+# 1. Create a release PR with version bumps and changelog
+# 2. Trigger CI checks on the PR (due to PAT usage)
+#
+# Publishing happens automatically when you merge the release PR.
+# Release-plz handles the dependency order automatically.
 
 permissions:
   pull-requests: write
@@ -32,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PR_DRAFT_PAT }}
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -40,11 +41,8 @@ jobs:
       - name: Run release-plz
         uses: release-plz/action@v0.5.102
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PR_DRAFT_PAT }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:
-          # Only create PR, don't release yet
-          # This prevents circular dependency issues during initial publishing
-          command: release-pr
           # Enable debug output
           rust_log: debug

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,45 @@
+name: Release-publish
+
+# This workflow publishes crates to crates.io when a release PR is merged.
+# It's triggered by pushes to main that contain version bumps.
+#
+# Release-plz automatically handles publishing in dependency order:
+# 1. eventcore-macros (no dependencies)
+# 2. eventcore (depends on macros)
+# 3. eventcore-memory & eventcore-postgres (depend on eventcore)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Only run when Cargo.toml files change (version bumps)
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+
+permissions:
+  contents: write
+  id-token: write  # For publishing to crates.io
+
+jobs:
+  release-publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    # Only run if the commit message indicates a release
+    if: contains(github.event.head_commit.message, 'chore: release')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Run release-plz release
+        uses: release-plz/action@v0.5.102
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        with:
+          command: release


### PR DESCRIPTION
## Description

Updated release-plz workflow to use the existing PR_DRAFT_PAT secret instead of GITHUB_TOKEN. This ensures CI checks are triggered on release PRs. Also split the workflow into two parts: one for creating release PRs and another for publishing when those PRs are merged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Security enhancement

## Performance Impact

None - workflow configuration only

<details>
<summary>Benchmark Results</summary>

```bash
# Run benchmarks before and after changes:
git checkout main
cargo bench --bench event_store -- --save-baseline main
git checkout your-branch
cargo bench --bench event_store -- --baseline main

# For realistic workload benchmarks:
cargo bench --bench realistic_workloads -- --save-baseline main
# ... switch branches ...
cargo bench --bench realistic_workloads -- --baseline main
```

</details>

## Submitter Checklist

- [x] Code follows project style guidelines
- [x] Changes are well-documented
- [x] All tests pass
- [x] Performance implications have been considered
- [x] Security implications have been reviewed
- [x] Breaking changes are documented
- [x] The change is backward compatible where possible

## Review Focus

The key changes are using PAT for authentication and splitting the release workflow. This should resolve both the CI triggering issue and allow automatic publishing in dependency order.