### PR TITLE
Explicitly enable release for all publishable crates

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,6 +9,9 @@ allow_dirty = true
 # TODO: Re-enable after initial release (temporarily disabled because workspace dependencies are not yet published to crates.io)
 dependencies_update = false
 
+# Note: Due to failed release attempts, v0.1.1 and v0.1.2 tags exist but weren't fully published.
+# The workspace is at v0.1.3 to bypass these issues.
+
 # Git configuration
 git_release_enable = true  # Create GitHub releases
 git_tag_enable = true      # Create git tags
@@ -39,18 +42,23 @@ commit_parsers = [
 [[package]]
 name = "eventcore-macros"
 # Macros crate needs to be published first
+release = true
 
 [[package]]
 name = "eventcore"
 # Core crate published after macros
+# Explicitly set release to ensure it's included
+release = true
 
 [[package]]
 name = "eventcore-memory"
 # Memory adapter depends on eventcore
+release = true
 
 [[package]]
 name = "eventcore-postgres"
 # Postgres adapter depends on eventcore
+release = true
 
 # Don't publish example and benchmark crates
 [[package]]


### PR DESCRIPTION
## Description

Added explicit `release = true` configuration for all publishable crates in release-plz.toml. The main eventcore crate was being skipped by release-plz due to version conflicts from previous failed release attempts.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Security enhancement

## Performance Impact

None - configuration change only

## Submitter Checklist

- [x] Code follows project style guidelines
- [x] Changes are well-documented
- [x] All tests pass
- [x] Performance implications have been considered
- [x] Security implications have been reviewed
- [x] Breaking changes are documented
- [x] The change is backward compatible where possible

## Review Focus

This ensures the main eventcore crate is included in release PRs alongside eventcore-memory and eventcore-postgres. The explicit configuration overrides any version conflict detection.