### PR TITLE
Run code coverage job concurrently with test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
-    needs: [test]  # Wait for tests to pass first
+    # Run concurrently with test jobs for faster CI
     
     services:
       postgres-main:


### PR DESCRIPTION
## Description

This PR optimizes the CI pipeline by running the code coverage job concurrently with test jobs instead of waiting for them to complete first. This reduces the overall CI pipeline duration without any functional changes.

### The Issue

The code coverage job had `needs: [test]`, making it wait for all test jobs (stable, beta, nightly) to complete before starting. However, the coverage job:
- Sets up its own PostgreSQL services
- Has its own dependency caching
- Runs tests independently with `cargo-llvm-cov`
- Doesn't reuse any artifacts from test jobs

This created an unnecessary bottleneck where coverage couldn't start until all test matrix jobs finished.

### The Solution

Remove the `needs: [test]` dependency, allowing the coverage job to run concurrently with other CI jobs. This should reduce total CI time by approximately the duration of the coverage job itself (several minutes).

### Impact

- **Faster CI feedback**: Coverage results available sooner
- **Better resource utilization**: More jobs running in parallel
- **No functional changes**: Coverage still runs the same tests
- **No risk**: Jobs are independent and don't interfere with each other

## Definition of Done Checklist

Please ensure all items in this checklist are completed before merging:
- [x] Code follows project style guidelines
- [x] Changes are well-documented
- [x] All tests pass
- [x] Performance implications have been considered
- [x] Security implications have been reviewed
- [x] Breaking changes are documented
- [x] The change is backward compatible where possible
