### PR TITLE
Update pre-commit hooks to use nextest for all tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,16 +15,9 @@ repos:
         files: \.(rs|toml)$
         pass_filenames: false
 
-      - id: cargo-test
-        name: cargo test
-        entry: cargo test --workspace --lib --bins --all-features
-        language: system
-        files: \.(rs|toml)$
-        pass_filenames: false
-
-      - id: cargo-test-integration
-        name: cargo integration tests
-        entry: cargo test --workspace --test '*' --all-features
+      - id: cargo-nextest
+        name: cargo nextest
+        entry: cargo nextest run --workspace --all-features
         language: system
         files: \.(rs|toml)$
         pass_filenames: false

--- a/eventcore-examples/Cargo.toml
+++ b/eventcore-examples/Cargo.toml
@@ -80,7 +80,3 @@ path = "src/distributed_ecommerce_example.rs"
 name = "axum_integration"
 path = "src/axum_integration_example.rs"
 
-[[bench]]
-name = "example_benchmarks"
-harness = false
-path = "src/benchmarks/bench.rs"

--- a/eventcore-examples/src/benchmarks/bench.rs
+++ b/eventcore-examples/src/benchmarks/bench.rs
@@ -1,5 +1,0 @@
-//! Benchmarks for eventcore examples - placeholder
-
-fn main() {
-    println!("Benchmarks not yet implemented");
-}

--- a/eventcore-examples/src/benchmarks/mod.rs
+++ b/eventcore-examples/src/benchmarks/mod.rs
@@ -1,7 +1,0 @@
-//! Performance benchmarks for EventCore examples
-//!
-//! This module will contain benchmarks in a future phase.
-
-#![allow(missing_docs)]
-
-// Placeholder until implementation

--- a/eventcore-examples/src/lib.rs
+++ b/eventcore-examples/src/lib.rs
@@ -25,7 +25,6 @@ pub mod ecommerce;
 pub mod sagas;
 
 // Benchmarks: Performance testing examples
-pub mod benchmarks;
 
 #[cfg(test)]
 mod tests {

--- a/eventcore-postgres/tests/connection_pool_tests.rs
+++ b/eventcore-postgres/tests/connection_pool_tests.rs
@@ -188,7 +188,7 @@ async fn test_performance_optimized_config() {
 async fn test_query_timeout_configuration() {
     let config = PostgresConfigBuilder::new()
         .database_url(test_database_url())
-        .query_timeout(Some(Duration::from_millis(100))) // Very short timeout
+        .query_timeout(Some(Duration::from_millis(500))) // Short timeout for testing
         .build();
 
     let store = PostgresEventStore::<serde_json::Value>::new(config)


### PR DESCRIPTION
This PR aligns pre-commit hooks with developer expectations that the entire ecosystem should be kept working.

## Changes
- Replace separate cargo test commands with a single nextest run that includes all targets except benchmarks
- Remove bogus benchmark placeholder from eventcore-examples that was causing nextest failures (real benchmarks exist in the dedicated eventcore-benchmarks crate)
- Fix flaky query timeout test by increasing timeout from 100ms to 500ms to account for database initialization time

## Why
Developers are expected to maintain the entire codebase, including examples. The pre-commit hooks should match what CI runs to catch issues early.

## Testing
All tests pass locally with PostgreSQL databases running via docker-compose.

## Definition of Done Checklist

Please ensure all items in this checklist are completed before merging:
- [x] Code follows project style guidelines
- [x] Changes are well-documented
- [x] All tests pass
- [x] Performance implications have been considered
- [x] Security implications have been reviewed
- [x] Breaking changes are documented
- [x] The change is backward compatible where possible
