### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-benchmarks"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-examples"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-integration-tests"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-macros"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-memory"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-postgres"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 authors = ["EventCore Contributors"]
 edition = "2021"
 rust-version = "1.70.0"
@@ -55,10 +55,10 @@ futures = "0.3.31"
 # Internal workspace crates
 # Version must be specified for crates.io publishing
 # These will be automatically updated by release-plz
-eventcore = { path = "eventcore", version = "0.1.4" }
-eventcore-postgres = { path = "eventcore-postgres", version = "0.1.4" }
-eventcore-memory = { path = "eventcore-memory", version = "0.1.4" }
-eventcore-macros = { path = "eventcore-macros", version = "0.1.4" }
+eventcore = { path = "eventcore", version = "0.1.5" }
+eventcore-postgres = { path = "eventcore-postgres", version = "0.1.5" }
+eventcore-memory = { path = "eventcore-memory", version = "0.1.5" }
+eventcore-macros = { path = "eventcore-macros", version = "0.1.5" }
 
 
 [workspace.lints.rust]


### PR DESCRIPTION
## Summary

Manually bumping version from 0.1.4 to 0.1.5 to trigger release-plz to create a new release PR.

## Why this is needed

After fixing the release-plz configuration to use package-specific tags, release-plz still won't create a release PR because:
- Version 0.1.4 is already published to crates.io for all packages
- release-plz checks the registry and sees the current version is already published
- Even though we deleted the old tags and fixed the tag format, this doesn't change the fact that 0.1.4 is already on crates.io

## What this does

- Bumps workspace version from 0.1.4 to 0.1.5
- Updates all internal workspace dependencies to use 0.1.5
- Once merged, release-plz will detect the new version and create a proper release PR

## Next steps

1. Merge this PR
2. release-plz should automatically create a new release PR for version 0.1.5
3. That release will use the new tag format: `eventcore-v0.1.5`, `eventcore-macros-v0.1.5`, etc.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Definition of Done Checklist

Please ensure all items in this checklist are completed before merging:

- [x] Code follows project style guidelines
- [x] Changes are well-documented
- [x] All tests pass
- [x] Performance implications have been considered
- [x] Security implications have been reviewed
- [x] Breaking changes are documented
- [x] The change is backward compatible where possible
