### PR TITLE
fix(release-plz): separate PR creation from publishing to prevent premature releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,14 +8,12 @@ name: Release-plz
 # - PR_DRAFT_PAT: GitHub PAT with repo permissions for creating PRs
 # - CARGO_REGISTRY_TOKEN: crates.io token for publishing
 #
-# The workflow automatically:
-# 1. Creates a release PR when changes are pushed to main
-# 2. Publishes to crates.io when the release PR is merged
+# The workflow has two different behaviors:
+# 1. On regular push to main: Creates/updates a release PR (release-pr command)
+# 2. When a release PR is merged: Publishes packages to crates.io (release command)
 #
-# Release-plz is smart enough to:
-# - Only create/update PRs when there are unreleased changes
-# - Only publish when its own release PR is merged
-# - Handle the dependency order automatically
+# This separation ensures that manual version bumps don't trigger immediate
+# publishing, and that packages are published in the correct dependency order.
 
 permissions:
   pull-requests: write
@@ -41,11 +39,43 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       
-      - name: Run release-plz
+      # Determine if this is a release PR merge by checking the commit message
+      - name: Check if this is a release PR merge
+        id: check_release
+        run: |
+          # Get the commit message of the HEAD commit
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          echo "Commit message: $COMMIT_MSG"
+          
+          # Check if this is a release PR merge (contains "chore: release")
+          if [[ "$COMMIT_MSG" =~ ^chore:\ release ]]; then
+            echo "This is a release PR merge"
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "This is a regular commit"
+            echo "is_release=false" >> $GITHUB_OUTPUT
+          fi
+      
+      # Run release-pr command for regular commits
+      - name: Create/Update Release PR
+        if: steps.check_release.outputs.is_release == 'false'
         uses: release-plz/action@v0.5.102
         env:
           GITHUB_TOKEN: ${{ secrets.PR_DRAFT_PAT }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:
+          command: release-pr
+          # Enable debug output
+          rust_log: debug
+      
+      # Run release command only for release PR merges
+      - name: Publish to crates.io
+        if: steps.check_release.outputs.is_release == 'true'
+        uses: release-plz/action@v0.5.102
+        env:
+          GITHUB_TOKEN: ${{ secrets.PR_DRAFT_PAT }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        with:
+          command: release
           # Enable debug output
           rust_log: debug

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,86 @@
+# EventCore Release Process
+
+This document describes the release process for the EventCore workspace.
+
+## Automated Release Process
+
+The project uses [release-plz](https://release-plz.dev/) for automated releases:
+
+1. When changes are pushed to `main`, release-plz creates/updates a release PR
+2. When the release PR is merged, release-plz publishes packages to crates.io
+
+## Known Issues
+
+### Package Publishing Order
+
+release-plz has a known issue where it doesn't always respect the dependency graph when publishing workspace packages. This can cause publishing failures when packages are published out of order.
+
+**Correct publishing order based on dependencies:**
+1. `eventcore-macros` (no internal dependencies)
+2. `eventcore` (depends on eventcore-macros)
+3. `eventcore-memory` (depends on eventcore)
+4. `eventcore-postgres` (depends on eventcore and eventcore-memory)
+
+### Manual Publishing Process
+
+If release-plz fails to publish packages in the correct order, you'll need to publish manually:
+
+```bash
+# 1. First, ensure you're on the latest main branch
+git checkout main
+git pull origin main
+
+# 2. Publish packages in the correct order
+cd eventcore-macros && cargo publish && cd ..
+# Wait for crates.io to index the package (~1-2 minutes)
+
+cd eventcore && cargo publish && cd ..
+# Wait for crates.io to index the package
+
+cd eventcore-memory && cargo publish && cd ..
+# Wait for crates.io to index the package
+
+cd eventcore-postgres && cargo publish && cd ..
+
+# 3. Create git tags for the release
+git tag -a eventcore-v0.1.X -m "Release eventcore v0.1.X"
+git tag -a eventcore-macros-v0.1.X -m "Release eventcore-macros v0.1.X"
+git tag -a eventcore-memory-v0.1.X -m "Release eventcore-memory v0.1.X"
+git tag -a eventcore-postgres-v0.1.X -m "Release eventcore-postgres v0.1.X"
+
+# 4. Push tags to GitHub
+git push origin --tags
+```
+
+Replace `0.1.X` with the actual version number.
+
+## Workflow Configuration
+
+The release workflow is split into two parts:
+
+1. **Release PR Creation**: Runs on push to main when it's NOT a release PR merge
+2. **Package Publishing**: Runs on push to main when it IS a release PR merge (commit message starts with "chore: release")
+
+This separation prevents manual version bumps from triggering immediate publishing.
+
+## Troubleshooting
+
+### "Package already published" errors
+
+If you see errors about packages already being published, check:
+1. Which packages have actually been published to crates.io
+2. Continue manual publishing from the next package in the dependency order
+
+### Version mismatch errors
+
+If you see errors about version requirements not being met:
+1. Ensure all workspace dependencies in `Cargo.toml` use the same version
+2. Check that the versions match what's in the package's `Cargo.toml`
+
+### Pre-commit hook failures
+
+Always ensure pre-commit hooks pass before attempting to publish. The hooks run:
+- Code formatting
+- Linting
+- Tests
+- Type checking

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -30,26 +30,33 @@ commit_parsers = [
   { message = "^.*", group = "Changes" },
 ]
 
-# Package-specific configuration for publishing order
+# Package-specific configuration
+# 
+# IMPORTANT: release-plz does not always respect dependency order when publishing.
+# See: https://github.com/release-plz/release-plz/issues/1316
+# 
+# The correct publishing order based on dependencies is:
+# 1. eventcore-macros (no internal dependencies)
+# 2. eventcore (depends on macros)
+# 3. eventcore-memory (depends on eventcore)
+# 4. eventcore-postgres (depends on eventcore and eventcore-memory)
+#
+# However, release-plz may publish in a different order, causing failures.
+# If this happens, packages need to be manually published in the correct order.
 [[package]]
 name = "eventcore-macros"
-# Macros crate needs to be published first
 release = true
 
 [[package]]
 name = "eventcore"
-# Core crate published after macros
-# Explicitly set release to ensure it's included
 release = true
 
 [[package]]
 name = "eventcore-memory"
-# Memory adapter depends on eventcore
 release = true
 
 [[package]]
 name = "eventcore-postgres"
-# Postgres adapter depends on eventcore
 release = true
 
 # Don't publish example and benchmark crates


### PR DESCRIPTION
## Summary

This PR fixes the issue where merging PR #101 (manual version bump) triggered immediate package publishing instead of creating a new release PR.

## Problem

The release-plz workflow was running both `release-pr` and `release` commands on every push to main. When a manual version bump was merged, release-plz detected that package versions were higher than published versions and immediately attempted to publish them to crates.io. This failed due to packages being published out of dependency order.

## Solution

- Modified the workflow to check the commit message
- Only runs `release` command for actual release PR merges (commits starting with "chore: release")  
- Regular commits to main now only run `release-pr` command
- This ensures manual version bumps create a release PR rather than publishing immediately

## Additional Changes

- Added documentation about the known publishing order issue (release-plz/release-plz#1316)
- Created `RELEASE_PROCESS.md` with manual publishing instructions as a fallback
- Updated `release-plz.toml` with warnings about the dependency ordering issue

## Test Plan

- [x] Pre-commit hooks pass
- [ ] CI workflow passes
- [ ] Verify that regular commits only create/update release PRs
- [ ] Verify that release PR merges trigger publishing

This should prevent version 0.1.6 and future releases from having the same issue we encountered with 0.1.5.

🤖 Generated with [Claude Code](https://claude.ai/code)