### PR TITLE
chore: release v0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-benchmarks"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-examples"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-integration-tests"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-macros"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-memory"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "eventcore-postgres"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 authors = ["EventCore Contributors"]
 edition = "2021"
 rust-version = "1.70.0"
@@ -55,10 +55,10 @@ futures = "0.3.31"
 # Internal workspace crates
 # Version must be specified for crates.io publishing
 # These will be automatically updated by release-plz
-eventcore = { path = "eventcore", version = "0.1.8" }
-eventcore-postgres = { path = "eventcore-postgres", version = "0.1.8" }
-eventcore-memory = { path = "eventcore-memory", version = "0.1.8" }
-eventcore-macros = { path = "eventcore-macros", version = "0.1.8" }
+eventcore = { path = "eventcore", version = "0.1.9" }
+eventcore-postgres = { path = "eventcore-postgres", version = "0.1.9" }
+eventcore-memory = { path = "eventcore-memory", version = "0.1.9" }
+eventcore-macros = { path = "eventcore-macros", version = "0.1.9" }
 
 
 [workspace.lints.rust]

--- a/eventcore-postgres/CHANGELOG.md
+++ b/eventcore-postgres/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/jwilger/eventcore/compare/eventcore-postgres-v0.1.8...eventcore-postgres-v0.1.9) - 2025-07-24
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.6](https://github.com/jwilger/eventcore/compare/eventcore-postgres-v0.1.5...eventcore-postgres-v0.1.6) - 2025-07-21
 
 ### Changes


### PR DESCRIPTION



## 🤖 New release

* `eventcore`: 0.1.8 -> 0.1.9
* `eventcore-postgres`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `eventcore-memory`: 0.1.8 -> 0.1.9
* `eventcore-macros`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

## `eventcore`

<blockquote>

## [0.1.8](https://github.com/jwilger/eventcore/compare/eventcore-v0.1.7...eventcore-v0.1.8) - 2025-07-23

### Fixed

- add clippy allow attribute to emit! macro to suppress vec_init_then_push warning ([#106](https://github.com/jwilger/eventcore/pull/106))
</blockquote>

## `eventcore-postgres`

<blockquote>

## [0.1.9](https://github.com/jwilger/eventcore/compare/eventcore-postgres-v0.1.8...eventcore-postgres-v0.1.9) - 2025-07-24

### Other

- update Cargo.toml dependencies
</blockquote>

## `eventcore-memory`

<blockquote>

## [0.1.6](https://github.com/jwilger/eventcore/compare/eventcore-memory-v0.1.5...eventcore-memory-v0.1.6) - 2025-07-21

### Changes

- update Cargo.toml dependencies
</blockquote>

## `eventcore-macros`

<blockquote>

## [0.1.4](https://github.com/jwilger/eventcore/compare/v0.1.3...v0.1.4) - 2025-07-21

### Changes

- Add CHANGELOG.md files to all workspace packages ([#72](https://github.com/jwilger/eventcore/pull/72))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).