### PR TITLE
ci: move release-plz off self-hosted-gregor to ubuntu-latest

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -39,7 +39,7 @@ jobs:
     name: release-plz
     uses: slipstream-eng/gha-workflows/.github/workflows/rust-release-plz.yml@main
     with:
-      runs-on: self-hosted-gregor
+      runs-on: ubuntu-latest
     secrets:
       cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       release-signing-key: ${{ secrets.RELEASE_SIGNING_KEY }}


### PR DESCRIPTION
## Summary
- Points the `release-plz` reusable-workflow call at `ubuntu-latest` instead of `self-hosted-gregor`, per the decision to deprioritize the self-hosted gregor runner while its infrastructure issues are worked out.
- No other changes: the reusable workflow (`slipstream-eng/gha-workflows/.github/workflows/rust-release-plz.yml@main`) already handles its own toolchain setup and is parameterized by `runs-on`, and org-level secrets (CARGO_REGISTRY_TOKEN, RELEASE_SIGNING_KEY, etc.) work identically on github-hosted runners.

## Test plan
- [ ] Confirm PR CI checks pass on github-hosted runners
- [ ] Confirm no regression to release-plz behavior (this workflow only runs on push to `main` / workflow_dispatch, so the release-pr/release jobs themselves won't execute as part of this PR's checks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation to run on GitHub-hosted infrastructure instead of a self-hosted runner.
  * No user-facing product behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->