### PR TITLE
chore: update repository references after transfer

### DIFF
--- a/.claude/rules/forgejo-issues.md
+++ b/.claude/rules/forgejo-issues.md
@@ -1,8 +1,8 @@
-# Forgejo Issue Conventions
+# GitHub Issue Conventions
 
 ## Repository
 
-`git.johnwilger.com/jwilger/eventcore`
+`github.com/jwilger/eventcore`
 
 ## Issue Types
 
@@ -35,8 +35,8 @@
 
 ## Hierarchy and Relationships
 
-Forgejo does not have GitHub's "sub-issue" primitive. Two substitutes are
-available; pick whichever fits the situation:
+Use GitHub issue task lists or sub-issues where available. If sub-issues are not
+enabled, use task-list references in the parent issue body:
 
 ### Parent/Child (containment)
 
@@ -47,34 +47,26 @@ Use a checklist in the parent issue body:
 - [ ] #43 sub-task two
 ```
 
-Forgejo renders these as live links and updates the checkbox as referenced
-issues close. This is the closest analog to GitHub's sub-issues.
+GitHub renders these as live links and updates the checkbox as referenced issues
+close.
 
 ### Blocker Relationships
 
-Forgejo supports issue dependencies natively. Mark them via the REST API:
+Represent blockers with explicit issue links in the body, for example:
 
-```bash
-# Issue #28 is blocked by #15
-curl -fsSL -X POST \
-  -H "Authorization: token $FORGEJO_TOKEN" \
-  -H "Content-Type: application/json" \
-  "https://git.johnwilger.com/api/v1/repos/jwilger/eventcore/issues/28/dependencies" \
-  -d '{"index": 15}'
+```markdown
+Depends on: #15
 ```
 
-Or with `tea`:
-
-```bash
-tea issues edit 28 --add-dependency 15
-```
+When starting work, check referenced blockers with `gh issue view` before
+creating a branch.
 
 ## Issue Assignment
 
 When starting work on an issue, assign it to the current authenticated user.
 
 ```bash
-tea issues edit 42 --assignees @me
+gh issue edit 42 --repo jwilger/eventcore --add-assignee @me
 ```
 
 Or via REST:
@@ -83,7 +75,7 @@ Or via REST:
 curl -fsSL -X PATCH \
   -H "Authorization: token $FORGEJO_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://git.johnwilger.com/api/v1/repos/jwilger/eventcore/issues/42" \
+  "https://api.github.com/repos/jwilger/eventcore/issues/42" \
   -d '{"assignees": ["jwilger"]}'
 ```
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -39,6 +39,6 @@ jobs:
     name: release-plz
     uses: jwilger/gha-workflows/.github/workflows/rust-release-plz.yml@main
     with:
-      runs-on: self-hosted-gregor
+      runs-on: ubuntu-latest
     secrets:
       op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -15,12 +15,12 @@
 #     release-plz.toml) and creating the GitHub release once a release PR has
 #     merged. Also a no-op when there is nothing new to publish.
 #
-# Both jobs mint their own git-write token from the org GitHub App and
-# SSH-sign commits/tags with RELEASE_SIGNING_KEY, so the resulting commit
-# satisfies main's required-signed-commits branch protection without this
-# repo needing to carry its own git-auth/git-signing/release-PR shell
-# scripts (formerly .forgejo/scripts/*.sh) -- that logic now lives once in
-# gha-workflows instead of being duplicated per repo.
+# Both jobs load a git-write PAT and SSH-sign commits/tags with
+# RELEASE_SIGNING_KEY, so the resulting commit satisfies main's
+# required-signed-commits branch protection without this repo needing to carry
+# its own git-auth/git-signing/release-PR shell scripts (formerly
+# .forgejo/scripts/*.sh) -- that logic now lives once in gha-workflows instead
+# of being duplicated per repo.
 
 name: Release (release-plz)
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   release-plz:
     name: release-plz
-    uses: jwilger/gha-workflows/.github/workflows/rust-release-plz.yml@main
+    uses: jwilger/gha-workflows/.github/workflows/rust-release-plz.yml@4f29cb994188c20786a9fda85ebabd113c910d89
     with:
       runs-on: ubuntu-latest
     secrets:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,7 +3,7 @@
 # Replaces the former two-file Forgejo pair (release-plz.yml + publish.yml)
 # with a single call into the org's shared two-phase release-plz reusable
 # workflow, which was generalized directly from this repo's own Forgejo
-# workflows (see slipstream-eng/gha-workflows commit history) and
+# workflows (see jwilger/gha-workflows commit history) and
 # already implements both phases as independent, idempotent jobs:
 #
 #   - release-pr: runs `release-plz release-pr` on every push to main. It is
@@ -37,9 +37,8 @@ permissions:
 jobs:
   release-plz:
     name: release-plz
-    uses: slipstream-eng/gha-workflows/.github/workflows/rust-release-plz.yml@main
+    uses: jwilger/gha-workflows/.github/workflows/rust-release-plz.yml@main
     with:
       runs-on: self-hosted-gregor
     secrets:
-      cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      release-signing-key: ${{ secrets.RELEASE_SIGNING_KEY }}
+      op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,14 +29,14 @@
 14. Integration tests must read like docs — Given/When/Then comments, only public APIs, no private hooks or mocks of internals.
 15. Duplication inside tests is acceptable when it mirrors how downstream users compose commands and stores.
 16. Prefer existing tracing/logging helpers over ad-hoc `println!` debugging noise.
-17. All work items are tracked in **GitHub Issues** at `github.com/slipstream-eng/eventcore`; use the `gh` CLI or direct REST calls for automation.
+17. All work items are tracked in **GitHub Issues** at `github.com/jwilger/eventcore`; use the `gh` CLI or direct REST calls for automation.
 18. Keep pre-commit hooks green: rerun fmt/clippy/nextest locally until clean before committing.
 19. Use Conventional Commits for all git commit messages and PR titles (type/scope: summary) so history stays machine-readable.
 
 ## Issue Tracking with GitHub Issues
 
 **IMPORTANT**: This project uses **GitHub Issues** for ALL issue tracking,
-hosted at `github.com/slipstream-eng/eventcore`.
+hosted at `github.com/jwilger/eventcore`.
 
 ### Labels
 
@@ -62,7 +62,7 @@ hosted at `github.com/slipstream-eng/eventcore`.
 
 The `gh` CLI is the recommended interface. It must be authenticated once with
 `gh auth login`. Direct calls to the GitHub REST API at
-`/repos/slipstream-eng/eventcore/...` are equivalent when `gh` is unavailable.
+`/repos/jwilger/eventcore/...` are equivalent when `gh` is unavailable.
 
 **Check for work:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,11 @@ Use `/core:develop` skill. Follow outside-in TDD:
 ### GitHub Issues
 
 All work items, feature requests, and bug reports are tracked as GitHub
-Issues at `github.com/slipstream-eng/eventcore`. At the start of each
+Issues at `github.com/jwilger/eventcore`. At the start of each
 development session, check open issues to understand current priorities.
 
 Use the `gh` CLI or direct calls to the GitHub REST API
-(`/repos/slipstream-eng/eventcore/issues`) to read and manage issues.
+(`/repos/jwilger/eventcore/issues`) to read and manage issues.
 
 ### Session Continuity
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 
 1. Fork the repository
 2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/eventcore.git`
-3. Add upstream remote: `git remote add upstream https://github.com/slipstream-eng/eventcore.git`
+3. Add upstream remote: `git remote add upstream https://github.com/jwilger/eventcore.git`
 4. Create a feature branch: `git checkout -b my-feature-branch`
 
 ## Development Setup
@@ -226,7 +226,7 @@ Keep hooks green before pushing.
 ## Task Tracking
 
 This project uses **GitHub Issues** at
-[github.com/slipstream-eng/eventcore](https://github.com/slipstream-eng/eventcore/issues)
+[github.com/jwilger/eventcore](https://github.com/jwilger/eventcore/issues)
 for all task tracking. See AGENTS.md for label conventions and CLI commands.
 
 ## Pull Request Process
@@ -321,7 +321,7 @@ When adding new features:
 
 ## Questions?
 
-- Open an [issue](https://github.com/slipstream-eng/eventcore/issues) for questions
+- Open an [issue](https://github.com/jwilger/eventcore/issues) for questions
 - Check existing issues before creating new ones
 - Join our community chat (to be added)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 version = "1.0.1"
 edition = "2024"
 license = "MIT"
-repository = "https://github.com/slipstream-eng/eventcore"
+repository = "https://github.com/jwilger/eventcore"
 
 [workspace.lints.rust]
 dead_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EventCore
 
-[![CI](https://github.com/slipstream-eng/eventcore/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/slipstream-eng/eventcore/actions/workflows/ci.yml)
+[![CI](https://github.com/jwilger/eventcore/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jwilger/eventcore/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/eventcore.svg)](https://crates.io/crates/eventcore)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -207,6 +207,6 @@ Specific compliance documentation is in development.
 
 For non-security questions, please use:
 
-- [GitHub Issues](https://github.com/slipstream-eng/eventcore/issues) for bug reports and feature requests
+- [GitHub Issues](https://github.com/jwilger/eventcore/issues) for bug reports and feature requests
 
 For security issues, use only the private email reporting process described above.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -168,7 +168,10 @@ This separation prevents manual version bumps from triggering immediate publishi
 
 ### crates.io Publishing Token
 
-The automated workflow uses a `CARGO_REGISTRY_TOKEN` stored as a GitHub Actions secret (set at the Slipstream organization or repository level) to authenticate with crates.io during publishing.
+The automated workflow uses `CARGO_REGISTRY_TOKEN` from the dedicated 1Password
+`Github Secrets` vault to authenticate with crates.io during publishing. GitHub
+Actions loads it through the repository-level `OP_SERVICE_ACCOUNT_TOKEN`
+bootstrap secret.
 
 **Required permissions:**
 
@@ -197,16 +200,16 @@ To rotate the crates.io publishing token:
    - Log in to [crates.io](https://crates.io/)
    - Navigate to Account Settings → API Tokens
    - Click "New Token"
-   - Name: `Slipstream GitHub Actions` (or similar)
+   - Name: `jwilger GitHub Actions` (or similar)
    - Scopes: `publish-update` (allows publishing new versions)
    - Click "Generate"
    - Copy the token immediately (it won't be shown again)
 
-2. **Update GitHub Actions secret:**
-   - Navigate to the Slipstream organization or repository Settings → Secrets and variables → Actions
-   - Find `CARGO_REGISTRY_TOKEN` in organization secrets
-   - Click "Edit" and paste the new token
-   - Save changes
+2. **Update 1Password runtime secret:**
+   - Open the `Github Secrets` 1Password vault
+   - Find `CARGO_REGISTRY_TOKEN`
+   - Replace the `credential` field with the new crates.io token
+   - GitHub Actions will load the value through `1password/load-secrets-action`
 
 3. **Revoke old token:**
    - Return to crates.io Account Settings → API Tokens
@@ -245,7 +248,7 @@ If you see errors about version requirements not being met:
 
 If you see "no token found" or "authentication failed" errors:
 
-1. Verify `CARGO_REGISTRY_TOKEN` is set in GitHub Actions secrets (Slipstream organization or repository level)
+1. Verify `CARGO_REGISTRY_TOKEN` is populated in the `Github Secrets` 1Password vault
 2. Check that the token hasn't expired or been revoked on crates.io
 3. Verify the token has `publish-update` permissions
 4. Rotate the token following the credential rotation procedure above

--- a/docs/manual/06-security/05-compliance.md
+++ b/docs/manual/06-security/05-compliance.md
@@ -7,7 +7,7 @@ reach for storage-layer or application-layer mechanisms instead.
 
 > **📋 Comprehensive Compliance Checklist**
 >
-> For a detailed compliance checklist covering OWASP, NIST, SOC2, PCI DSS, GDPR, and HIPAA requirements, see our [COMPLIANCE_CHECKLIST.md](https://github.com/slipstream-eng/eventcore/blob/main/COMPLIANCE_CHECKLIST.md).
+> For a detailed compliance checklist covering OWASP, NIST, SOC2, PCI DSS, GDPR, and HIPAA requirements, see our [COMPLIANCE_CHECKLIST.md](https://github.com/jwilger/eventcore/blob/main/COMPLIANCE_CHECKLIST.md).
 >
 > This checklist provides actionable items for achieving compliance with major security frameworks and regulations.
 

--- a/eventcore-demo/src/lib.rs
+++ b/eventcore-demo/src/lib.rs
@@ -1,6 +1,6 @@
 //! # EventCore bank demo
 //!
-//! A small, runnable demonstration of [EventCore](https://git.johnwilger.com/Slipstream/eventcore)
+//! A small, runnable demonstration of [EventCore](https://github.com/jwilger/eventcore)
 //! with the PostgreSQL backend. It models a bank with three account-level
 //! commands ([`OpenAccount`], [`Deposit`], [`Withdraw`]) plus a multi-stream
 //! atomic [`Transfer`] — the centerpiece showing EventCore's signature

--- a/eventcore-sqlite/README.md
+++ b/eventcore-sqlite/README.md
@@ -1,6 +1,6 @@
 # eventcore-sqlite
 
-SQLite backend for the [EventCore](https://github.com/slipstream-eng/eventcore)
+SQLite backend for the [EventCore](https://github.com/jwilger/eventcore)
 event-sourcing library, built on `rusqlite`.
 
 ## Cargo features

--- a/eventcore/src/lib.rs
+++ b/eventcore/src/lib.rs
@@ -100,7 +100,7 @@
 //! # }
 //! ```
 //!
-//! From here, see the [user manual](https://git.johnwilger.com/Slipstream/eventcore)
+//! From here, see the [user manual](https://github.com/jwilger/eventcore)
 //! for projections, multi-stream atomicity, and backend selection, or the
 //! `eventcore-demo` crate for a complete bank application backed by PostgreSQL.
 //!


### PR DESCRIPTION
Updates post-transfer repository references and moves workflow runtime secret access
to the shared 1Password `Github Secrets` vault.

This only changes repositories that were part of the `slipstream-eng` migration
inventory.

Secret-loading changes:

- keep `OP_SERVICE_ACCOUNT_TOKEN` as the only GitHub Actions bootstrap secret
- load runtime values with `1password/load-secrets-action@v4`
- use `op://Github Secrets/...` references for cargo/Hex publish tokens,
  the GitHub release automation PAT, and the release signing SSH key
- remove Codecov and OpenAI/Anthropic/Claude token usage from CI
- use npm trusted publishing/OIDC instead of `NPM_TOKEN`
- keep built-in `GITHUB_TOKEN` usage unchanged

Runner migration:

- replace `self-hosted-gregor` with `ubuntu-latest` where the transferred
  personal-account repos no longer have an eligible shared runner
- add the repo-standard Determinate Systems Nix installer/cache actions before
  `nix develop` steps where needed

Verification run where applicable:

- `git diff --check`
- YAML parse check with Python `yaml.safe_load`
- `actionlint`

Notes:

- Historical generated changelog links were left alone.
- Forgejo product/runtime references were left alone unless they pointed at
  migrated source repositories.
- The remaining 1Password runtime secrets are populated: Cargo, Hex, GitHub
  release automation PAT, and release signing key.
- `GH_RELEASE_AUTOMATION_TOKEN` is a fine-grained PAT. Required repository
  permissions: Contents read/write, Pull requests read/write, Issues read/write
  for release-please repos, Metadata read-only. Do not grant Actions/Workflows
  unless release automation must edit workflow files; do not grant
  Administration unless protected tag rules block release tag creation.
- npm packages must be configured in npm as trusted publishers for their
  GitHub repository and publish workflow before tokenless npm publishing works.
